### PR TITLE
Fix histogram support

### DIFF
--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -379,7 +379,7 @@ module Druid
 
       def histogram(metric, type = "equalBuckets", args = {})
         @query.aggregations << Aggregation.new({
-          type: "approxHistogramFold",
+          type: "approxHistogram",
           name: "raw_#{metric}",
           fieldName: metric,
         })


### PR DESCRIPTION
### Tested at druid 0.8.1

``` bash
$ cat test.json
{
    "queryType": "timeseries",
    "dataSource": "requests",
    "intervals": [ "2010-01-01/2020-01-01" ],
    "granularity": "all",
    "aggregations": [
    {"type": "doubleSum", "fieldName": "duration", "name": "duration"},
        { "type": "approxHistogram", "name" : "raw_duration", "fieldName" : "duration" }
    ],
    "postAggregations":[
      { "type" : "quantiles", "name" : "quantiles", "fieldName" : "raw_duration", "probabilities" : [ 0.25, 0.50, 0.75, 0.95 ] }
    ]
}

$ curl -X POST 'http://localhost:8084/druid/v2/?pretty' -H 'content-type: application/json'  -d  @test.json
[ {
  "timestamp" : "2015-11-18T08:45:04.000Z",
  "result" : {
    "duration" : 36686.89776611328,
    "quantiles" : {
      "probabilities" : [ 0.25, 0.5, 0.75, 0.95 ],
      "quantiles" : [ 753.85187, 1407.783, 2920.844, 3392.5525 ],
      "min" : 554.1291,
      "max" : 4494.9365
    },
    "raw_duration" : {
      "breaks" : [ -102.672119140625, 554.1290893554688, 1210.9302978515625, 1867.7314453125, 2524.53271484375, 3181.333984375, 3838.13525390625, 4494.9365234375 ],
      "counts" : [ 1.0, 6.0, 4.0, 0.0, 4.0, 3.0, 1.0 ]
    }
  }
} ]
```
### Same query with ruby gem

``` ruby
  #...
  query.histogram(:duration, 'quantiles', {"probabilities" => [ 0.25, 0.50, 0.75, 0.95 ]}).
    count(:count).
    granularity(:all).
    filter(event_source: event_source.id)
  #...

=> [{"timestamp"=>"2015-11-12T00:33:47.000Z",
  "result"=>
   {"duration"=>{"probabilities"=>[0.25, 0.5, 0.75, 0.95], "quantiles"=>[2808.3394, 2944.521, 4353.3906, 15034.78], "min"=>2344.1316, "max"=>21866.8},
    "count"=>41,
    "raw_duration"=>
     {"breaks"=>[-909.646728515625, 2344.131591796875, 5597.91015625, 8851.6884765625, 12105.466796875, 15359.2451171875, 18613.0234375, 21866.80078125],
      "counts"=>[1.0, 33.0, 0.0, 0.0, 5.0, 1.0, 1.0]}}}]
```
