### PR TITLE
parse full error response

### DIFF
--- a/lib/druid/data_source.rb
+++ b/lib/druid/data_source.rb
@@ -74,22 +74,35 @@ module Druid
           return self.post(query)
         end
 
-        raise Error.new(response), "request failed"
+        raise Error.new(response)
       end
 
       MultiJson.load(response.body)
     end
 
     class Error < StandardError
-      attr_reader :response
+      QUERY_TIMEOUT = 'Query timeout'.freeze
+      QUERY_INTERRUPTED = 'Query interrupted'.freeze
+      QUERY_CANCELLED = 'Query cancelled'.freeze
+      RESOURCE_LIMIT_EXCEEDED = 'Resource limit exceeded'.freeze
+      UNKNOWN_EXCEPTION = 'Unknown exception'.freeze
+
+      attr_reader :error, :error_message, :error_class, :host, :response
+
       def initialize(response)
         @response = response
+        parsed_body = MultiJson.load(response.body)
+        @error, @error_message, @error_class, @host = parsed_body.values_at(*%w(
+          error
+          errorMessage
+          errorClass
+          host
+        ))
       end
 
       def message
-        MultiJson.load(response.body)["error"]
+        error
       end
     end
-
   end
 end

--- a/lib/druid/data_source.rb
+++ b/lib/druid/data_source.rb
@@ -81,12 +81,6 @@ module Druid
     end
 
     class Error < StandardError
-      QUERY_TIMEOUT = 'Query timeout'.freeze
-      QUERY_INTERRUPTED = 'Query interrupted'.freeze
-      QUERY_CANCELLED = 'Query cancelled'.freeze
-      RESOURCE_LIMIT_EXCEEDED = 'Resource limit exceeded'.freeze
-      UNKNOWN_EXCEPTION = 'Unknown exception'.freeze
-
       attr_reader :error, :error_message, :error_class, :host, :response
 
       def initialize(response)
@@ -102,6 +96,26 @@ module Druid
 
       def message
         error
+      end
+
+      def query_timeout?
+        error == 'Query timeout'.freeze
+      end
+
+      def query_interrupted?
+        error == 'Query interrupted'.freeze
+      end
+
+      def query_cancelled?
+        error == 'Query cancelled'.freeze
+      end
+
+      def resource_limit_exceeded?
+        error == 'Resource limit exceeded'.freeze
+      end
+
+      def unknown_exception?
+        error == 'Unknown exception'.freeze
       end
     end
   end

--- a/spec/lib/data_source_spec.rb
+++ b/spec/lib/data_source_spec.rb
@@ -19,20 +19,34 @@ describe Druid::DataSource do
     end
 
     it 'raises on request failure' do
-      # MRI
-      stub_request(:post, 'http://www.example.com/druid/v2').
-        with(:body => "{\"context\":{\"queryId\":null},\"queryType\":\"timeseries\",\"intervals\":[\"2013-04-04T00:00:00+00:00/2013-04-04T00:00:00+00:00\"],\"granularity\":\"all\",\"dataSource\":\"test\"}",
-          :headers => { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json', 'User-Agent' => 'Ruby' }).
-        to_return(:status => 666, :body => 'Strange server error', :headers => {})
-      # JRuby ... *sigh
-      stub_request(:post, 'http://www.example.com/druid/v2').
-        with(:body => "{\"context\":{\"queryId\":null},\"granularity\":\"all\",\"intervals\":[\"2013-04-04T00:00:00+00:00/2013-04-04T00:00:00+00:00\"],\"queryType\":\"timeseries\",\"dataSource\":\"test\"}",
-          :headers => { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type' => 'application/json', 'User-Agent' => 'Ruby' }).
-        to_return(:status => 666, :body => 'Strange server error', :headers => {})
+      stub_request(:post, 'http://www.example.com/druid/v2')
+        .with(
+          :body => %q({"context":{"queryId":null},"queryType":"timeseries","intervals":["2013-04-04T00:00:00+00:00/2013-04-04T00:00:00+00:00"],"granularity":"all","dataSource":"test"}),
+          :headers => {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'User-Agent' => 'Ruby',
+          }
+        )
+        .to_return(
+          :status => 500,
+          :body => %q({"error":"Unknown exception","errorMessage":"NullPointerException","errorClass":"java.lang.NullPointerException","host":"www.example.com"}),
+          :headers => {},
+        )
+
       ds = Druid::DataSource.new('test/test', 'http://www.example.com/druid/v2')
       query = Druid::Query::Builder.new.interval('2013-04-04', '2013-04-04').granularity(:all).query
       query.context.queryId = nil
-      expect { ds.post(query) }.to raise_error(Druid::DataSource::Error)
+
+      expect { ds.post(query) }.to raise_error { |error|
+        expect(error).to be_a(Druid::DataSource::Error)
+        expect(error.message).to eq(error.error)
+        expect(error.error).to eq('Unknown exception')
+        expect(error.error_message).to eq('NullPointerException')
+        expect(error.error_class).to eq('java.lang.NullPointerException')
+        expect(error.host).to eq('www.example.com')
+      }
     end
   end
 

--- a/spec/lib/data_source_spec.rb
+++ b/spec/lib/data_source_spec.rb
@@ -46,6 +46,7 @@ describe Druid::DataSource do
         expect(error.error_message).to eq('NullPointerException')
         expect(error.error_class).to eq('java.lang.NullPointerException')
         expect(error.host).to eq('www.example.com')
+        expect(error).to be_unknown_exception
       }
     end
   end


### PR DESCRIPTION
This maintains backwards compatibility, i.e. `#message` on error returns the Druid error, not the message the Ruby error was constructed with.