### PR TITLE
Use of hyperUniqueCardinality on post aggregations.

### DIFF
--- a/lib/druid/post_aggregation.rb
+++ b/lib/druid/post_aggregation.rb
@@ -163,7 +163,7 @@ module Druid
 
     def initialize(attributes = {})
       super
-      @type = 'fieldAccess'
+      @type ||= 'fieldAccess'
     end
 
     def field_names

--- a/spec/lib/query_spec.rb
+++ b/spec/lib/query_spec.rb
@@ -141,6 +141,28 @@ describe Druid::Query do
         @query.postagg { js('{ return a_with_b - a; }').as b }
       }.to raise_error
     end
+
+    it 'build a post aggregation with hyperUniqueCardinality' do
+      post_agg = Druid::PostAggregationOperation.new(
+        Druid::PostAggregationField.new(fieldName: 'a', type: 'hyperUniqueCardinality'),
+        :/,
+        2
+      )
+      post_agg.name = 'a_2'
+      @query.query.postAggregations << post_agg
+
+      expect(JSON.parse(@query.query.to_json)['postAggregations']).to eq(
+        [{
+          'type' => 'arithmetic',
+          'fn' => '/',
+          'fields' => [
+            { 'type' => 'hyperUniqueCardinality', 'fieldName' => 'a' },
+            { 'type' => 'constant', 'value' => 2 }
+          ],
+          'name' => 'a_2'
+        }]
+      )
+    end
   end
 
   it 'builds aggregations on long_sum' do


### PR DESCRIPTION
Using the method `postagg` on the Query::Builder class, is not possible to use the `hyperUniqueCardinality`.

Even if the post aggregation is created from scratch, the only two types allowed for the fields are `constant` and `fieldAccess`. This occurs because is not allowed to set the type on `PostAggregationField`.

 It can be fixed setting the instance variable `@type` with a default value (fieldAccess) only if in the initialization this attribute has not been set.