### PR TITLE
support typed aggregation

### DIFF
--- a/lib/druid/aggregation.rb
+++ b/lib/druid/aggregation.rb
@@ -3,13 +3,13 @@ module Druid
     include ActiveModel::Model
 
     attr_accessor :type
-    validates :type, inclusion: { in: %w(count longSum doubleSum min max javascript cardinality hyperUnique) }
+    validates :type, inclusion: { in: %w(count longSum doubleSum floatSum longMin longMax doubleMin doubleMax floatMin floatMax hyperUnique) }
 
     attr_accessor :name
     validates :name, presence: true
 
     class FieldnameValidator < ActiveModel::EachValidator
-      TYPES = %w(count longSum doubleSum min max hyperUnique)
+      TYPES = %w(longSum doubleSum floatSum longMin longMax doubleMin doubleMax floatMin floatMax)
       def validate_each(record, attribute, value)
         if TYPES.include?(record.type)
           record.errors.add(attribute, 'may not be blank') if value.blank?

--- a/lib/druid/query.rb
+++ b/lib/druid/query.rb
@@ -393,7 +393,7 @@ module Druid
       end
 
       ### aggregations
-      [:count, :long_sum, :double_sum, :min, :max, :hyper_unique].each do |method_name|
+      %i[count long_sum double_sum float_sum long_min long_max double_min double_max float_min float_max hyper_unique].each do |method_name|
         define_method method_name do |*metrics|
           metrics.flatten.compact.each do |metric|
             @query.aggregations << Aggregation.new({


### PR DESCRIPTION
Current druid doesn't support 'max' and 'min'.(2018-06005) They should be *Typed*.