### PR TITLE
In filter uses "in" type filter

### DIFF
--- a/lib/druid/filter.rb
+++ b/lib/druid/filter.rb
@@ -188,11 +188,16 @@ module Druid
     alias :'!=' :neq
 
     def in(*args)
-      filter_multiple(args.flatten, 'or', :eq)
+      # filter_multiple(args.flatten, 'or', :eq)
+      @type = 'in'
+      @values = args.flatten
+      ::Kernel.raise 'Values cannot be empty' if @values.empty?
+      self
     end
 
     def nin(*args)
-      filter_multiple(args.flatten, 'and', :neq)
+      # filter_multiple(args.flatten, 'and', :neq)
+      return !self.in(args.flatten)
     end
 
     def filter_multiple(values, operator, method)


### PR DESCRIPTION
Used to filter method generate following json body..
```
{
  "filter":{
    "type":"and",
    "fields":[
      {
        "type":"or",
        "fields":[
          {
            "dimension":"host",
            "type":"selector",
            "value":"mosol-es-dev1.dakao.io"
          },
          {
            "dimension":"host",
            "type":"selector",
            "value":"mosol-es-dev2.dakao.io"
          },
          {
            "dimension":"host",
            "type":"selector",
            "value":"mosol-es-dev3.dakao.io"
          }
        ]
      },
      {
        "dimension":"metric",
        "type":"selector",
        "value":"system.memory.realused"
      }
    ]
  }
}
```

Why don't we use real `in` type filter?
```
{
  "filter":{
    "type":"and",
    "fields":[
      {
        "type":"in",
        "dimension":"host",
        "values":[
          "mosol-es-dev1.dakao.io",
          "mosol-es-dev2.dakao.io",
          "mosol-es-dev3.dakao.io"
        ]
      },
      {
        "type":"selector",
        "dimension":"metric",
        "value":"system.cpu.real"
      }
    ]
  }
}
```

