### PR TITLE
Fix js postagg field extraction

### DIFF
--- a/lib/druid/post_aggregation.rb
+++ b/lib/druid/post_aggregation.rb
@@ -206,7 +206,7 @@ module Druid
     private
 
     def extract_fields(function)
-      match = function.match(/function\((.+)\)/)
+      match = function.match(/function\((.+?)\)/)
       raise 'Invalid Javascript function' unless match && match.captures
       match.captures.first.split(',').map(&:strip)
     end


### PR DESCRIPTION
Fields are getting wrongly extracted if js used in postagg contains parentheses in its body, eg ``function(a,b){a/(1+b);}`` becomes ` ["a", "b){a/(1+b"]`.