### PR TITLE
Allow optional http params to be passed to the data source

### DIFF
--- a/lib/druid/data_source.rb
+++ b/lib/druid/data_source.rb
@@ -6,7 +6,7 @@ module Druid
 
     attr_reader :name, :uri, :metrics, :dimensions
 
-    def initialize(name, uri)
+    def initialize(name, uri, http_params: {})
       @name = name.split('/').last
       uri = uri.sample if uri.is_a?(Array)
       if uri.is_a?(String)
@@ -14,6 +14,7 @@ module Druid
       else
         @uri = uri
       end
+      @http_params = http_params
     end
 
     def metadata
@@ -35,6 +36,11 @@ module Druid
       response = Net::HTTP.new(uri.host, uri.port).start do |http|
         http.open_timeout = 10 # if druid is down fail fast
         http.read_timeout = nil # we wait until druid is finished
+        if @http_params
+          for param, value in @http_params
+            http.send("#{param}=", value)
+          end
+        end
         http.request(req)
       end
 
@@ -67,6 +73,11 @@ module Druid
         Net::HTTP.new(uri.host, uri.port).start do |http|
           http.open_timeout = 10 # if druid is down fail fast
           http.read_timeout = nil # we wait until druid is finished
+          if @http_params
+            for param, value in @http_params
+              http.send("#{param}=", value)
+            end
+          end
           http.request(req)
         end
       end


### PR DESCRIPTION
I have a Druid instance that is requires client certificates and thus would need the following net/http parameters:

```ruby
client.use_ssl = true
client.cert = cert
client.key = key
```

Currently, AFAIK this cannot be done in ruby-druid. This PR adds this functionality by allowing any param to be passed to the DataSource constructor.

This could be used now as follows:

```ruby
data_source = Druid::DataSource.new('service/source', 'http://localhost:8080/druid/v2', http_params: {use_ssl: true, cert: cert, key: key})
```